### PR TITLE
treewide: Support for sensitive field generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "env_logger",
  "log",
  "nix",
+ "rand",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ env_logger = "0.7"
 Inflector = "0.11.4"
 log = "0.4"
 nix = "0.17.0"
+rand = "0.7"
 secrecy = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/kbs2/generator.rs
+++ b/src/kbs2/generator.rs
@@ -1,0 +1,44 @@
+use rand::Rng;
+
+use crate::kbs2::config;
+use crate::kbs2::error::Error;
+use crate::kbs2::util;
+
+pub trait Generator {
+    fn name(&self) -> &str;
+    fn secret(&self) -> Result<String, Error>;
+}
+
+impl Generator for config::GeneratorCommandConfig {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn secret(&self) -> Result<String, Error> {
+        let (command, args) = util::parse_and_split_args(&self.command)?;
+        let args = args.iter().map(AsRef::as_ref).collect::<Vec<&str>>();
+
+        util::run_with_output(&command, &args)
+    }
+}
+
+impl Generator for config::GeneratorInternalConfig {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn secret(&self) -> Result<String, Error> {
+        // NOTE(ww): Disallow non-ASCII, to prevent gibberish indexing below.
+        if !self.alphabet.is_ascii() {
+            return Err("generator alphabet contains non-ascii characters".into());
+        }
+
+        let mut rng = rand::thread_rng();
+        let alphabet = self.alphabet.as_bytes();
+        let secret = (0..self.length)
+            .map(|_| alphabet[rng.gen_range(0, alphabet.len())] as char)
+            .collect::<String>();
+
+        Ok(secret)
+    }
+}

--- a/src/kbs2/input.rs
+++ b/src/kbs2/input.rs
@@ -23,13 +23,17 @@ fn terse_fields(
     // NOTE(ww): Handling generated inputs in terse mode is a bit of a mess.
     // First, we collect all inputs, expecting blank slots where we'll fill
     // in the generated values.
-    let mut fields = input.split(TERSE_IFS).map(|s| s.to_string()).collect::<Vec<String>>();
+    let mut fields = input
+        .split(TERSE_IFS)
+        .map(|s| s.to_string())
+        .collect::<Vec<String>>();
     if fields.len() != names.len() {
         return Err(format!(
             "field count mismatch: expected {}, found {}",
             names.len(),
             fields.len()
-        ).into());
+        )
+        .into());
     }
 
     // Then, if we have a generator configured, we iterate over the

--- a/src/kbs2/mod.rs
+++ b/src/kbs2/mod.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod command;
 pub mod config;
 pub mod error;
+pub mod generator;
 pub mod input;
 pub mod record;
 pub mod session;

--- a/src/kbs2/util.rs
+++ b/src/kbs2/util.rs
@@ -1,11 +1,46 @@
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::kbs2::error::Error;
+
+pub fn parse_and_split_args(argv: &str) -> Result<(String, Vec<String>), Error> {
+    let args = match shell_words::split(argv) {
+        Ok(args) => args,
+        Err(_) => return Err(format!("failed to split command-line arguments: {}", argv).into()),
+    };
+
+    let (command, args) = args
+        .split_first()
+        .map(|t| (t.0.to_owned(), t.1.to_owned()))
+        .ok_or::<Error>("missing one or more arguments in command".into())?;
+
+    Ok((command, args))
+}
 
 pub fn run_with_status(command: &str, args: &[&str]) -> Option<bool> {
     Command::new(command)
         .args(args)
         .status()
         .map_or(None, |s| Some(s.success()))
+}
+
+pub fn run_with_output(command: &str, args: &[&str]) -> Result<String, Error> {
+    let output = Command::new(command)
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()?;
+
+    if output.stdout.is_empty() {
+        return Err(format!("expected output from {}, but none given", command).into());
+    }
+
+    let mut output = String::from_utf8(output.stdout)?;
+    if output.ends_with('\n') {
+        output.pop();
+    }
+
+    Ok(output)
 }
 
 pub fn current_timestamp() -> u64 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,19 @@ fn app<'a>() -> App<'a> {
             App::new("new")
                 .about("create a new record")
                 .arg(
+                    Arg::with_name("kind")
+                        .about("the kind of record to create")
+                        .index(1)
+                        .required(true)
+                        .possible_values(kbs2::record::RECORD_KINDS),
+                )
+                .arg(
+                    Arg::with_name("label")
+                        .about("the record's label")
+                        .index(2)
+                        .required(true),
+                )
+                .arg(
                     Arg::with_name("force")
                         .about("overwrite, if already present")
                         .short('f')
@@ -62,17 +75,11 @@ fn app<'a>() -> App<'a> {
                         .long("terse"),
                 )
                 .arg(
-                    Arg::with_name("kind")
-                        .about("the kind of record to create")
-                        .index(1)
-                        .required(true)
-                        .possible_values(kbs2::record::RECORD_KINDS),
-                )
-                .arg(
-                    Arg::with_name("label")
-                        .about("the record's label")
-                        .index(2)
-                        .required(true),
+                    Arg::with_name("generator")
+                        .about("use the given generator to generate sensitive fields")
+                        .short('g')
+                        .long("generator")
+                        .takes_value(true),
                 ),
         )
         .subcommand(


### PR DESCRIPTION
Adds support for two kinds of generators: "internal" and "command".

"internal" generators use their configured alphabet and length to
produce a random secret, while "command" generators execute a
command (with optional arguments) and retain its output as the
secret.

Closes #8.