### PR TITLE
kbs2: Hooks for `kbs2 pass`

### DIFF
--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -178,6 +178,11 @@ pub fn dump(matches: &ArgMatches, session: &session::Session) -> Result<(), Erro
 pub fn pass(matches: &ArgMatches, session: &session::Session) -> Result<(), Error> {
     log::debug!("getting a login's password");
 
+    if let Some(pre_hook) = &session.config.commands.pass.pre_hook {
+        log::debug!("pre-hook: {}", pre_hook);
+        session.config.call_hook(pre_hook, &[])?;
+    }
+
     let label = matches.value_of("label").unwrap();
     let record = session.get_record(&label)?;
 
@@ -212,6 +217,11 @@ pub fn pass(matches: &ArgMatches, session: &session::Session) -> Result<(), Erro
                 if clear_after {
                     ctx.set_contents("".to_owned())
                         .map_err(|_| "unable to clear the clipboard")?;
+
+                    if let Some(clear_hook) = &session.config.commands.pass.clear_hook {
+                        log::debug!("clear-hook: {}", clear_hook);
+                        session.config.call_hook(clear_hook, &[])?;
+                    }
                 }
             }
             Err(_) => return Err("clipboard fork failed".into()),
@@ -219,6 +229,11 @@ pub fn pass(matches: &ArgMatches, session: &session::Session) -> Result<(), Erro
         }
     } else {
         println!("{}", password);
+    }
+
+    if let Some(post_hook) = &session.config.commands.pass.post_hook {
+        log::debug!("post-hook: {}", post_hook);
+        session.config.call_hook(post_hook, &[])?;
     }
 
     Ok(())

--- a/src/kbs2/config.rs
+++ b/src/kbs2/config.rs
@@ -119,6 +119,15 @@ pub struct PassConfig {
     pub clear_after: bool,
     #[serde(rename = "x11-clipboard")]
     pub x11_clipboard: X11Clipboard,
+    #[serde(deserialize_with = "deserialize_optional_with_tilde")]
+    #[serde(rename = "pre-hook")]
+    pub pre_hook: Option<String>,
+    #[serde(deserialize_with = "deserialize_optional_with_tilde")]
+    #[serde(rename = "post-hook")]
+    pub post_hook: Option<String>,
+    #[serde(deserialize_with = "deserialize_optional_with_tilde")]
+    #[serde(rename = "clear-hook")]
+    pub clear_hook: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, Serialize)]
@@ -133,6 +142,9 @@ impl Default for PassConfig {
             clipboard_duration: 10,
             clear_after: true,
             x11_clipboard: X11Clipboard::Clipboard,
+            pre_hook: None,
+            post_hook: None,
+            clear_hook: None,
         }
     }
 }


### PR DESCRIPTION
Adds three new hooks, all specific to `kbs2 pass`:

* pre-hook: Run before the record is retrieved
* post-hook: Run after the password is printed/copied
* clear-hook: Run after the clipboard is cleared (if cleared)

Closes #18.