### PR TITLE
Wrapped key support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "env_logger",
  "log",
  "nix",
+ "pinentry",
  "rand",
  "secrecy",
  "serde",
@@ -738,6 +739,19 @@ checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "byteorder",
  "crypto-mac",
+]
+
+[[package]]
+name = "pinentry"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36bf2b9e565399e61073d044c01f57e4890f59b0762b3649c5f94e83439141cf"
+dependencies = [
+ "log",
+ "nom",
+ "secrecy",
+ "which",
+ "zeroize",
 ]
 
 [[package]]
@@ -1215,6 +1229,15 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ env_logger = "0.7"
 Inflector = "0.11.4"
 log = "0.4"
 nix = "0.17.0"
+pinentry = "0.1"
 rand = "0.7"
 secrecy = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ The `keyfile` setting records the path to the private half of the age keypair us
 `kbs2 init` pre-populates this setting; users should **not** modify it **unless** also modifying
 the `public-key` setting (e.g., to point to a pre-existing age keypair).
 
+### `wrapped` (default: `true`)
+
+The `wrapped` settings records whether `keyfile` is a "wrapped" private key, i.e. whether
+the private key itself is encrypted with a master password.
+
+By default, `kbs2 init` asks the user for a master password and creates a wrapped key.
+See the [`kbs2 init`](#kbs2-init) documentation for more information.
+
 ### `store` (default: `<user data directory>/kbs2`)
 
 The `store` setting records the path to the secret store, i.e. where records are kept.

--- a/src/kbs2/backend.rs
+++ b/src/kbs2/backend.rs
@@ -119,20 +119,14 @@ where
     }
 }
 
-pub struct AgeCLI {
-    public_key: String,
-    keyfile: String,
-}
+pub struct AgeCLI {}
 
 impl AgeCLI {
     pub fn new(config: &config::Config) -> Result<AgeCLI, Error> {
         if config.wrapped {
-            Err("foo".into())
+            Err("the RageCLI backend doesn't support wrapped keys".into())
         } else {
-            Ok(AgeCLI {
-                public_key: config.public_key.clone(),
-                keyfile: config.keyfile.clone(),
-            })
+            Ok(AgeCLI {})
         }
     }
 }
@@ -151,7 +145,11 @@ pub struct RageCLI {}
 
 impl RageCLI {
     pub fn new(config: &config::Config) -> Result<RageCLI, Error> {
-        Ok(RageCLI {})
+        if config.wrapped {
+            Err("the RageCLI backend doesn't support wrapped keys".into())
+        } else {
+            Ok(RageCLI {})
+        }
     }
 }
 
@@ -177,7 +175,11 @@ impl RageLib {
             .parse::<age::keys::RecipientKey>()
             .map_err(|e| format!("unable to parse public key (backend reports: {:?})", e))?;
 
-        let identities = age::keys::Identity::from_file(config.keyfile.clone())?;
+        let identities = if config.wrapped {
+            unimplemented!();
+        } else {
+            age::keys::Identity::from_file(config.keyfile.clone())?
+        };
 
         if identities.len() != 1 {
             return Err(format!(

--- a/src/kbs2/backend.rs
+++ b/src/kbs2/backend.rs
@@ -26,6 +26,9 @@ pub trait Backend {
     fn create_keypair(path: &Path) -> Result<String, Error>
     where
         Self: Sized;
+    // fn create_wrapped_keypair(path: &Path) -> Result<String, Error>
+    // where
+    //     Self: Sized;
     fn encrypt(&self, config: &config::Config, record: &Record) -> Result<String, Error>;
     fn decrypt(&self, config: &config::Config, encrypted: &str) -> Result<Record, Error>;
 }
@@ -116,7 +119,23 @@ where
     }
 }
 
-pub struct AgeCLI {}
+pub struct AgeCLI {
+    public_key: String,
+    keyfile: String,
+}
+
+impl AgeCLI {
+    pub fn new(config: &config::Config) -> Result<AgeCLI, Error> {
+        if config.wrapped {
+            Err("foo".into())
+        } else {
+            Ok(AgeCLI {
+                public_key: config.public_key.clone(),
+                keyfile: config.keyfile.clone(),
+            })
+        }
+    }
+}
 
 impl CLIBackend for AgeCLI {
     fn age() -> &'static str {
@@ -129,6 +148,12 @@ impl CLIBackend for AgeCLI {
 }
 
 pub struct RageCLI {}
+
+impl RageCLI {
+    pub fn new(config: &config::Config) -> Result<RageCLI, Error> {
+        Ok(RageCLI {})
+    }
+}
 
 impl CLIBackend for RageCLI {
     fn age() -> &'static str {

--- a/src/kbs2/config.rs
+++ b/src/kbs2/config.rs
@@ -28,7 +28,7 @@ pub static DEFAULT_KEY_BASENAME: &str = "key";
 // the user's data directory by default.
 pub static STORE_BASEDIR: &str = "kbs2";
 
-#[derive(Default, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     #[serde(rename = "age-backend")]
     pub age_backend: BackendKind,
@@ -36,6 +36,7 @@ pub struct Config {
     pub public_key: String,
     #[serde(deserialize_with = "deserialize_with_tilde")]
     pub keyfile: String,
+    pub wrapped: bool,
     #[serde(deserialize_with = "deserialize_with_tilde")]
     pub store: String,
     #[serde(deserialize_with = "deserialize_optional_with_tilde")]
@@ -256,6 +257,7 @@ pub fn initialize(config_dir: &Path) -> Result<(), Error> {
         age_backend: BackendKind::RageLib,
         public_key: public_key,
         keyfile: keyfile.to_str().unwrap().into(),
+        wrapped: false,
         store: data_dir()?,
         pre_hook: None,
         post_hook: None,

--- a/src/kbs2/config.rs
+++ b/src/kbs2/config.rs
@@ -24,6 +24,8 @@ pub static CONFIG_BASENAME: &str = "kbs2.conf";
 // the configuration directory.
 pub static DEFAULT_KEY_BASENAME: &str = "key";
 
+pub static UNWRAPPED_KEY_SHM_NAME: &str = "__kbs2_unwrapped_key";
+
 // The default base directory name for the secret store, placed relative to
 // the user's data directory by default.
 pub static STORE_BASEDIR: &str = "kbs2";

--- a/src/kbs2/config.rs
+++ b/src/kbs2/config.rs
@@ -32,6 +32,7 @@ pub static CONFIG_BASENAME: &str = "kbs2.conf";
 // the configuration directory.
 pub static DEFAULT_KEY_BASENAME: &str = "key";
 
+// The name for the POSIX shared memory object in which the unwrapped key is stored.
 pub static UNWRAPPED_KEY_SHM_NAME: &str = "__kbs2_unwrapped_key";
 
 // The default base directory name for the secret store, placed relative to

--- a/src/kbs2/error.rs
+++ b/src/kbs2/error.rs
@@ -89,3 +89,11 @@ impl From<nix::Error> for Error {
         }
     }
 }
+
+impl From<pinentry::Error> for Error {
+    fn from(err: pinentry::Error) -> Error {
+        Error {
+            message: err.to_string(),
+        }
+    }
+}

--- a/src/kbs2/error.rs
+++ b/src/kbs2/error.rs
@@ -81,3 +81,11 @@ impl From<serde_json::error::Error> for Error {
         }
     }
 }
+
+impl From<nix::Error> for Error {
+    fn from(err: nix::Error) -> Error {
+        Error {
+            message: err.to_string(),
+        }
+    }
+}

--- a/src/kbs2/session.rs
+++ b/src/kbs2/session.rs
@@ -19,7 +19,7 @@ impl Session {
         let backend: Box<dyn backend::Backend> = match config.age_backend {
             BackendKind::RageLib => Box::new(backend::RageLib::new(&config)?),
             BackendKind::RageCLI => Box::new(backend::RageCLI {}),
-            BackendKind::AgeCLI => Box::new(backend::AgeCLI {}),
+            BackendKind::AgeCLI => Box::new(backend::AgeCLI::new(&config)?),
         };
 
         Ok(Session { backend, config })

--- a/src/kbs2/session.rs
+++ b/src/kbs2/session.rs
@@ -18,7 +18,7 @@ impl Session {
 
         let backend: Box<dyn backend::Backend> = match config.age_backend {
             BackendKind::RageLib => Box::new(backend::RageLib::new(&config)?),
-            BackendKind::RageCLI => Box::new(backend::RageCLI {}),
+            BackendKind::RageCLI => Box::new(backend::RageCLI::new(&config)?),
             BackendKind::AgeCLI => Box::new(backend::AgeCLI::new(&config)?),
         };
 

--- a/src/kbs2/util.rs
+++ b/src/kbs2/util.rs
@@ -1,3 +1,6 @@
+use pinentry::PassphraseInput;
+use secrecy::SecretString;
+
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -34,6 +37,18 @@ pub fn run_with_output(command: &str, args: &[&str]) -> Result<String, Error> {
     }
 
     Ok(output)
+}
+
+pub fn get_password() -> Result<SecretString, Error> {
+    if let Some(mut input) = PassphraseInput::with_default_binary() {
+        input
+            .with_description("Enter your master kbs2 password")
+            .with_prompt("Password:")
+            .interact()
+            .map_err(|e| e.into())
+    } else {
+        Err("foo".into())
+    }
 }
 
 pub fn current_timestamp() -> u64 {

--- a/src/kbs2/util.rs
+++ b/src/kbs2/util.rs
@@ -47,7 +47,7 @@ pub fn get_password() -> Result<SecretString, Error> {
             .interact()
             .map_err(|e| e.into())
     } else {
-        Err("foo".into())
+        Err("Couldn't get pinentry program for password prompt".into())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ fn app<'a>() -> App<'a> {
                         .long("keygen"),
                 ),
         )
+        .subcommand(App::new("unlock").about("unwrap the private key for use"))
+        .subcommand(App::new("lock").about("remove the unwrapped key, if any, from shared memory"))
         .subcommand(
             App::new("new")
                 .about("create a new record")
@@ -215,9 +217,25 @@ fn run() -> Result<(), kbs2::error::Error> {
     log::debug!("config dir: {:?}", config_dir);
     std::fs::create_dir_all(&config_dir)?;
 
-    // `init` is a special case, since it doesn't have access to a preexisting config.
+    // Subcommand dispatch happens here. All subcommands take a `Session`, with three exceptions:
+    //
+    // * `kbs2 init` doesn't have access to a preexisting config, and so needs to be separated
+    //   from the config-loading behavior of all other subcommands.
+    //
+    // * `kbs2 unlock` exists so that all commands that make use of a session don't have to
+    //   prompt for the master password themselves. That means that it can't take a session of
+    //   its own.
+    //
+    // * `kbs2 lock` exists to remove the shared memory object created by `kbs2 unlock`. Taking
+    //   a session would mean that it would attempt to pointlessly unlock the key before re-locking.
     if let ("init", Some(matches)) = matches.subcommand() {
         kbs2::command::init(&matches, &config_dir)
+    } else if let ("unlock", Some(matches)) = matches.subcommand() {
+        let config = kbs2::config::load(&config_dir)?;
+        kbs2::command::unlock(&matches, &config)
+    } else if let ("lock", Some(matches)) = matches.subcommand() {
+        let config = kbs2::config::load(&config_dir)?;
+        kbs2::command::lock(&matches, &config)
     } else {
         let config = kbs2::config::load(&config_dir)?;
         log::debug!("loaded config: {:?}", config);


### PR DESCRIPTION
This is an experimental approach to #23, using a POSIX shared memory object to persist the unwrapped private key. Currently, only the `RageLib` backend supports wrapped keys -- all others return an error if decryption with a wrapped key is requested.

Notes:

* Needs `create_wrapped_keypair` for `trait Backend`, so that the default can be changed to a wrapped key
* Needs `kbs2 unlock` and `kbs2 lock` to expose the master authentication/session expiry steps
* Maybe: A fallback from failure to access a pinentry-compatible interface for the password prompt
* Maybe: `kbs2 wrap` to automate the process of wrapping an already present key

Closes #23.