### PR TITLE
kbs2: Add `kbs2 generate`

### DIFF
--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -361,10 +361,7 @@ pub fn generate(matches: &ArgMatches, session: &session::Session) -> Result<(), 
         match session.config.get_generator(generator_name) {
             Some(generator) => generator,
             None => {
-                return Err(format!(
-                    "couldn't find a generator named {}",
-                    generator_name
-                ).into())
+                return Err(format!("couldn't find a generator named {}", generator_name).into())
             }
         }
     };

--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -354,3 +354,20 @@ pub fn edit(matches: &ArgMatches, session: &session::Session) -> Result<(), Erro
 
     Ok(())
 }
+
+pub fn generate(matches: &ArgMatches, session: &session::Session) -> Result<(), Error> {
+    let generator = {
+        let generator_name = matches.value_of("generator").unwrap();
+        match session.config.get_generator(generator_name) {
+            Some(generator) => generator,
+            None => {
+                return Err(format!(
+                    "couldn't find a generator named {}",
+                    generator_name
+                ).into())
+            }
+        }
+    };
+
+    Ok(println!("{}", generator.secret()?))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,16 @@ fn app<'a>() -> App<'a> {
                         .long("preserve-timestamp"),
                 ),
         )
+        .subcommand(
+            App::new("generate")
+                .about("generate secret values using a generator")
+                .arg(
+                    Arg::with_name("generator")
+                        .about("the generator to use")
+                        .index(1)
+                        .default_value("default"),
+                ),
+        )
 }
 
 fn run() -> Result<(), kbs2::error::Error> {
@@ -261,6 +271,7 @@ fn run() -> Result<(), kbs2::error::Error> {
             ("pass", Some(matches)) => kbs2::command::pass(&matches, &session)?,
             ("env", Some(matches)) => kbs2::command::env(&matches, &session)?,
             ("edit", Some(matches)) => kbs2::command::edit(&matches, &session)?,
+            ("generate", Some(matches)) => kbs2::command::generate(&matches, &session)?,
             (cmd, Some(matches)) => {
                 let cmd = format!("kbs2-{}", cmd);
 


### PR DESCRIPTION
This doesn't undo the current generation behavior in terse mode; that'll be removed as I more generally refactor the way input is done.

Closes #28.