### PR TITLE
kbs2: Backend unit tests, refactoring

### DIFF
--- a/src/kbs2/record.rs
+++ b/src/kbs2/record.rs
@@ -11,7 +11,7 @@ pub enum FieldKind {
     Sensitive(&'static str),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Record {
     pub timestamp: u64,
     pub label: String,

--- a/src/kbs2/session.rs
+++ b/src/kbs2/session.rs
@@ -71,7 +71,7 @@ impl Session {
             _ => e.into(),
         })?;
 
-        match self.backend.decrypt(&self.config, &record_contents) {
+        match self.backend.decrypt(&record_contents) {
             Ok(record) => Ok(record),
             Err(e) => Err(e),
         }
@@ -80,7 +80,7 @@ impl Session {
     pub fn add_record(&self, record: &record::Record) -> anyhow::Result<()> {
         let record_path = Path::new(&self.config.store).join(&record.label);
 
-        let record_contents = self.backend.encrypt(&self.config, record)?;
+        let record_contents = self.backend.encrypt(record)?;
         std::fs::write(&record_path, &record_contents)?;
 
         Ok(())


### PR DESCRIPTION
Adds unit tests for `RageLib`, refactors `Backend` more generally
to avoid the need to repeatedly pass config objects.

See #10.