### PR TITLE
kbs2: Use KBS2_CONFIG_DIR as a default config dir value

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ fn app<'a>() -> App<'a> {
                 .short('c')
                 .long("config-dir")
                 .value_name("FILE")
-                .takes_value(true),
+                .takes_value(true)
+                .env("KBS2_CONFIG_DIR"),
         )
         .arg(
             Arg::with_name("completions")


### PR DESCRIPTION
This establishes the following precedence:

* `--config-dir DIR`
* `KBS2_CONFIG_DIR`
* The default, i.e. `~/.config/kbs2`

This has the nice consequence of ensuring that custom subcommands use the right configuration directory when invoking `kbs2` on their own without requiring them to do something ugly like:

```bash
$ kbs2 -c "${KBS2_CONFIG_DIR}" whatever -a -b -c
```

Hooks are not guaranteed to receive `KBS2_CONFIG_DIR` in their environment. This probably needs to be fixed and will require a more involved change (since a `Config` doesn't know the directory that produced it).