### PR TITLE
README: Add AUR package instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ $ sudo dpkg -i kbs2_X.X.X_amd64.deb
 $ sudo apt-get -f install
 ```
 
+### Arch Linux
+
+`kbs2` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=kbs2&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```bash
+yay -S kbs2
+```
+
 Other distributions will be supported sooner or later. Help us by looking at the
 [open packaging issues](https://github.com/woodruffw/kbs2/labels/C%3Apackaging)!
 


### PR DESCRIPTION
Hey,
I'm an [Arch Linux](https://aur.archlinux.org) package [maintainer](https://github.com/orhun/PKGBUILDs). I'm submitting this PR to let you know that I created the following packages for the installation of `kbs2` on Arch Linux and other distributions that support installing packages from [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository):

* [kbs2](https://aur.archlinux.org/packages/kbs2/) (builds from source)
* [kbs2-git](https://aur.archlinux.org/packages/kbs2-git/) (VCS/development package)

I also updated README.md about installation from AUR. (b943689) (resolves #77)

PS: I can also create a `-bin` package if you provide a pre-compiled x86_64 binary along with the release artifacts.

BR,
orhun.