### PR TITLE
refactor: Better separate interactive and backend components

### DIFF
--- a/src/kbs2/backend.rs
+++ b/src/kbs2/backend.rs
@@ -1,6 +1,6 @@
 use age::armor::{ArmoredReader, ArmoredWriter, Format};
 use anyhow::{anyhow, Context, Result};
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 
 use std::io::{Read, Write};
 use std::path::Path;
@@ -8,7 +8,6 @@ use std::path::Path;
 use crate::kbs2::agent;
 use crate::kbs2::config;
 use crate::kbs2::record::Record;
-use crate::kbs2::util;
 
 /// Represents the operations that all age backends are capable of.
 pub trait Backend {
@@ -25,7 +24,7 @@ pub trait Backend {
     /// NOTE: Like `create_keypair`, this writes an ASCII-armored private component.
     /// It also prompts the user to enter a password for encrypting the generated
     /// private key.
-    fn create_wrapped_keypair(path: &Path) -> Result<String>
+    fn create_wrapped_keypair(path: &Path, password: SecretString) -> Result<String>
     where
         Self: Sized;
 
@@ -85,8 +84,7 @@ impl Backend for RageLib {
         Ok(keypair.to_public().to_string())
     }
 
-    fn create_wrapped_keypair(path: &Path) -> Result<String> {
-        let password = util::get_password()?;
+    fn create_wrapped_keypair(path: &Path, password: SecretString) -> Result<String> {
         let keypair = age::x25519::Identity::generate();
 
         let wrapped_key = {

--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -29,7 +29,13 @@ pub fn init(matches: &ArgMatches, config_dir: &Path) -> Result<()> {
         ));
     }
 
-    config::initialize(&config_dir, !matches.is_present("insecure-not-wrapped"))
+    let password = if matches.is_present("insecure-not-wrapped") {
+        Some(util::get_password()?)
+    } else {
+        None
+    };
+
+    config::initialize(&config_dir, password)
 }
 
 /// Implements the `kbs2 agent` command (and subcommands).


### PR DESCRIPTION
`Backend::create_wrapped_keypair` now takes the `SecretString` that it should wrap with, instead of using `util::get_password` to directly prompt for it.

Config initialization now takes an `Option<SecretString>` instead of a `bool` to indicate the creation of a wrapped keypair.