### PR TITLE
refactor(agent): agent::run -> Agent::run

### DIFF
--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -44,10 +44,11 @@ pub fn agent(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     log::debug!("agent subcommand dispatch");
 
     if matches.subcommand().is_none() {
+        let mut agent = agent::Agent::new()?;
         if !matches.is_present("foreground") {
             Daemonize::new().start()?;
         }
-        agent::run()?;
+        agent.run()?;
         return Ok(());
     }
 


### PR DESCRIPTION
Allows us to separate agent initialization from running, which
makes it possible to print the former's error(s) before daemonizing.