### PR TITLE
kbs2: Forbid unwrap/expect/panic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
         run: |
           rustup update
           rustup component add clippy
-          cargo clippy -- -D warnings
+          cargo clippy -- \
+            -D warnings -D clippy::expect_used -D clippy::unwrap_used -D clippy::panic
   test:
     strategy:
       matrix:

--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -30,6 +30,7 @@ pub fn init(matches: &ArgMatches, config_dir: &Path) -> Result<()> {
         ));
     }
 
+    #[allow(clippy::unwrap_used)]
     let store_dir = Path::new(matches.value_of_os("store-dir").unwrap());
 
     // Warn, but don't fail, if the store directory is already present.
@@ -113,6 +114,7 @@ pub fn new(matches: &ArgMatches, config: &config::Config) -> Result<()> {
         session.config.call_hook(pre_hook, &[])?;
     }
 
+    #[allow(clippy::unwrap_used)]
     let label = matches.value_of("label").unwrap();
     if session.has_record(label) && !matches.is_present("force") {
         return Err(anyhow!("refusing to overwrite a record without --force"));
@@ -121,6 +123,7 @@ pub fn new(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     let terse = atty::isnt(Stream::Stdin) || matches.is_present("terse");
 
     let generator = if matches.is_present("generate") {
+        #[allow(clippy::unwrap_used)]
         let generator_name = matches.value_of("generator").unwrap();
 
         Some(
@@ -134,6 +137,7 @@ pub fn new(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     };
 
     // TODO: new_* below is a little silly. This should be de-duped.
+    #[allow(clippy::unwrap_used)]
     match matches.value_of("kind").unwrap() {
         "login" => new_login(label, terse, &session, generator)?,
         "environment" => new_environment(label, terse, &session, generator)?,
@@ -218,6 +222,7 @@ pub fn list(matches: &ArgMatches, config: &config::Config) -> Result<()> {
             let record = session.get_record(&label)?;
 
             if filter_kind {
+                #[allow(clippy::unwrap_used)]
                 let kind = matches.value_of("kind").unwrap();
                 if record.body.to_string() != kind {
                     continue;
@@ -248,6 +253,7 @@ pub fn rm(matches: &ArgMatches, config: &config::Config) -> Result<()> {
 
     let session: Session = config.try_into()?;
 
+    #[allow(clippy::unwrap_used)]
     let label = matches.value_of("label").unwrap();
     session.delete_record(label)?;
 
@@ -265,6 +271,7 @@ pub fn dump(matches: &ArgMatches, config: &config::Config) -> Result<()> {
 
     let session: Session = config.try_into()?;
 
+    #[allow(clippy::unwrap_used)]
     let label = matches.value_of("label").unwrap();
     let record = session.get_record(&label)?;
 
@@ -298,6 +305,7 @@ pub fn pass(matches: &ArgMatches, config: &config::Config) -> Result<()> {
         session.config.call_hook(pre_hook, &[])?;
     }
 
+    #[allow(clippy::unwrap_used)]
     let label = matches.value_of("label").unwrap();
     let record = session.get_record(&label)?;
 
@@ -413,6 +421,7 @@ pub fn env(matches: &ArgMatches, config: &config::Config) -> Result<()> {
 
     let session: Session = config.try_into()?;
 
+    #[allow(clippy::unwrap_used)]
     let label = matches.value_of("label").unwrap();
     let record = session.get_record(&label)?;
 
@@ -455,6 +464,7 @@ pub fn edit(matches: &ArgMatches, config: &config::Config) -> Result<()> {
 
     log::debug!("editor: {}, args: {:?}", editor, editor_args);
 
+    #[allow(clippy::unwrap_used)]
     let label = matches.value_of("label").unwrap();
     let record = session.get_record(&label)?;
 
@@ -494,6 +504,7 @@ pub fn edit(matches: &ArgMatches, config: &config::Config) -> Result<()> {
 /// Implements the `kbs2 generate` command.
 pub fn generate(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     let generator = {
+        #[allow(clippy::unwrap_used)]
         let generator_name = matches.value_of("generator").unwrap();
         match config.get_generator(generator_name) {
             Some(generator) => generator,

--- a/src/kbs2/config.rs
+++ b/src/kbs2/config.rs
@@ -402,7 +402,10 @@ pub fn initialize<P: AsRef<Path>>(
             // NOTE(ww): Not actually serialized; just here to make the compiler happy.
             config_dir: config_dir,
             public_key: public_key,
-            keyfile: keyfile.to_str().unwrap().into(),
+            keyfile: keyfile
+                .to_str()
+                .ok_or_else(|| anyhow!("unrepresentable keyfile path: {:?}", keyfile))?
+                .into(),
             agent_autostart: true,
             wrapped: wrapped,
             store: store,
@@ -424,11 +427,15 @@ pub fn initialize<P: AsRef<Path>>(
 /// Given a path to a `kbs2` configuration directory, loads the configuration
 /// file within and returns the resulting `Config`.
 pub fn load<P: AsRef<Path>>(config_dir: P) -> Result<Config> {
-    let config_path = config_dir.as_ref().join(CONFIG_BASENAME);
+    let config_dir = config_dir.as_ref();
+    let config_path = config_dir.join(CONFIG_BASENAME);
     let contents = fs::read_to_string(config_path)?;
 
     Ok(Config {
-        config_dir: config_dir.as_ref().to_str().unwrap().into(),
+        config_dir: config_dir
+            .to_str()
+            .ok_or_else(|| anyhow!("unrepresentable config dir path: {:?}", config_dir))?
+            .into(),
         ..toml::from_str(&contents).map_err(|e| anyhow!("config loading error: {}", e))?
     })
 }

--- a/src/kbs2/session.rs
+++ b/src/kbs2/session.rs
@@ -54,10 +54,18 @@ impl<'a> Session<'a> {
 
             // NOTE(ww): This unwrap is safe, since file_name always returns Some
             // for non-directories.
-            let label = path.file_name().unwrap();
+            #[allow(clippy::expect_used)]
+            let label = path
+                .file_name()
+                .expect("impossible: is_file=true for path but file_name=None");
 
             // NOTE(ww): This one isn't safe, but we don't care. Non-UTF-8 labels aren't supported.
-            labels.push(label.to_str().unwrap().into());
+            labels.push(
+                label
+                    .to_str()
+                    .ok_or_else(|| anyhow!("unrepresentable record label: {:?}", label))?
+                    .into(),
+            );
         }
 
         Ok(labels)

--- a/src/kbs2/util.rs
+++ b/src/kbs2/util.rs
@@ -79,9 +79,10 @@ pub fn get_password<S: AsRef<OsStr>>(
 pub fn current_timestamp() -> u64 {
     // NOTE(ww): This unwrap should be safe, since every time should be
     // greater than or equal to the epoch.
+    #[allow(clippy::expect_used)]
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap()
+        .expect("impossible: system time is before the UNIX epoch")
         .as_secs()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    #[allow(clippy::unwrap_used)]
     let config_dir = Path::new(matches.value_of_os("config-dir").unwrap());
     log::debug!("config dir: {:?}", config_dir);
     std::fs::create_dir_all(&config_dir)?;


### PR DESCRIPTION
Bans any un-annotated uses of `unwrap`/`expect`/`panic` from the codebase, and reviews + annotates all of the current ones.