### PR TITLE
`kbs2 dump`: allow multiple records 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All versions prior to 0.2.1 are untracked.
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+* CLI: `kbs2 dump` can now dump multiple records in one invocation.
+
 ## [0.3.0] - 2021-05-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -344,14 +344,14 @@ $ kbs2 rm foobar
 dump a record
 
 USAGE:
-    kbs2 dump [FLAGS] <label>
+    kbs2 dump [FLAGS] <label>...
 
 ARGS:
-    <label>    the record's label
+    <label>...    the label of the record(s) to dump
 
 FLAGS:
     -h, --help    Prints help information
-    -j, --json    dump in JSON format
+    -j, --json    dump in JSON format (JSONL when multiple)
 ```
 
 #### Examples
@@ -381,7 +381,14 @@ $ kbs2 dump -j pets.com | json_pp
       "kind" : "Login"
    }
 }
+```
 
+Dump multiple records, demonstrating JSONL:
+
+```bash
+$ kbs2 dump -j carthage roma
+{"timestamp":1590363392,"label":"bepis","body":{"kind":"Login","fields":{"username":"hamilcar","password":"ihatecato"}}}
+{"timestamp":1590363392,"label":"conk","body":{"kind":"Login","fields":{"username":"cato","password":"carthagodelendaest"}}}
 ```
 
 ### `kbs2 pass`

--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -271,22 +271,25 @@ pub fn dump(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     let session: Session = config.try_into()?;
 
     #[allow(clippy::unwrap_used)]
-    let label = matches.value_of("label").unwrap();
-    let record = session.get_record(&label)?;
+    let labels: Vec<_> = matches.values_of("label").unwrap().collect();
 
-    if matches.is_present("json") {
-        println!("{}", serde_json::to_string(&record)?);
-    } else {
-        println!("Label {}\nKind {}", label, record.body);
+    for label in labels {
+        let record = session.get_record(&label)?;
 
-        match record.body {
-            RecordBody::Login(l) => {
-                println!("Username {}\nPassword {}", l.username, l.password)
+        if matches.is_present("json") {
+            println!("{}", serde_json::to_string(&record)?);
+        } else {
+            println!("Label {}\nKind {}", label, record.body);
+
+            match record.body {
+                RecordBody::Login(l) => {
+                    println!("Username {}\nPassword {}", l.username, l.password)
+                }
+                RecordBody::Environment(e) => {
+                    println!("Variable {}\nValue {}", e.variable, e.value)
+                }
+                RecordBody::Unstructured(u) => println!("Contents {}", u.contents),
             }
-            RecordBody::Environment(e) => {
-                println!("Variable {}\nValue {}", e.variable, e.value)
-            }
-            RecordBody::Unstructured(u) => println!("Contents {}", u.contents),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,14 +159,14 @@ fn app<'a, P: AsRef<OsStr>>(default_config_dir: &'a P, default_store_dir: &'a P)
                 .about("dump a record")
                 .arg(
                     Arg::new("label")
-                        .about("the record's label")
+                        .about("the label of the record(s) to dump")
                         .index(1)
                         .required(true)
                         .multiple(true),
                 )
                 .arg(
                     Arg::new("json")
-                        .about("dump in JSON format")
+                        .about("dump in JSON format (JSONL when multiple)")
                         .short('j')
                         .long("json"),
                 ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,8 @@ fn app<'a, P: AsRef<OsStr>>(default_config_dir: &'a P, default_store_dir: &'a P)
                     Arg::new("label")
                         .about("the record's label")
                         .index(1)
-                        .required(true),
+                        .required(true)
+                        .multiple(true),
                 )
                 .arg(
                     Arg::new("json")


### PR DESCRIPTION
This allows users to batch what would otherwise be multiple `kbs2 dump`
invocations into a single invocation, making things slightly simpler
and faster.

It's most useful in conjunction with the `--json` flag, since
`kbs2 dump` will emit one JSON record per line (and tools like
`jq` natively understand JSONL).
