### PR TITLE
Refactor the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ All versions prior to 0.2.1 are untracked.
 
 ### Added
 
-* CLI: `kbs2 dump` can now dump multiple records in one invocation.
+* CLI: `kbs2 dump` can now dump multiple records in one invocation
+([#191](https://github.com/woodruffw/kbs2/pull/191))
+
+### Changed
+
+* Agent: The agent's internal representation and protocol have been refactored
+([#193](https://github.com/woodruffw/kbs2/pull/193))
 
 ### Fixed
 

--- a/src/kbs2/agent.rs
+++ b/src/kbs2/agent.rs
@@ -402,6 +402,7 @@ impl Client {
 
     /// Issue the given request to the agent, returning the agent's `Response`.
     fn request(&self, body: RequestBody) -> Result<Response> {
+        #[allow(clippy::redundant_field_names)]
         let req = Request {
             protocol: PROTOCOL_VERSION,
             body: body,

--- a/src/kbs2/backend.rs
+++ b/src/kbs2/backend.rs
@@ -68,12 +68,16 @@ impl RageLib {
 
             let client = agent::Client::new().with_context(|| "failed to connect to kbs2 agent")?;
 
-            if !client.query_key(&config.keyfile)? {
-                client.add_key(&config.keyfile, util::get_password(None, &config.pinentry)?)?;
+            if !client.query_key(&config.public_key)? {
+                client.add_key(
+                    &config.public_key,
+                    &config.keyfile,
+                    util::get_password(None, &config.pinentry)?,
+                )?;
             }
 
             let unwrapped_key = client
-                .get_key(&config.keyfile)
+                .get_key(&config.public_key)
                 .with_context(|| format!("agent has no unwrapped key for {}", config.keyfile))?;
 
             log::debug!("parsing unwrapped key");

--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -94,13 +94,13 @@ fn agent_unwrap(_matches: &ArgMatches, config: &config::Config) -> Result<()> {
     }
 
     let client = agent::Client::new()?;
-    if client.query_key(&config.keyfile)? {
+    if client.query_key(&config.public_key)? {
         println!("kbs2 agent already has this key; ignoring.");
         return Ok(());
     }
 
     let password = util::get_password(None, &config.pinentry)?;
-    client.add_key(&config.keyfile, password)?;
+    client.add_key(&config.public_key, &config.keyfile, password)?;
 
     Ok(())
 }
@@ -663,7 +663,7 @@ pub fn rekey(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     {
         let client = agent::Client::new()?;
         client.flush_keys()?;
-        client.add_key(&config.keyfile, new_password)?;
+        client.add_key(&config.public_key, &config.keyfile, new_password)?;
     }
 
     // Create a new session from the new config and use it to re-encrypt each record.


### PR DESCRIPTION
Adds protocol versioning to the agent, and refactors the key management per the notes in #187.

Closes #187.