### PR TITLE
kbs2: add `kbs2 agent query`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All versions prior to 0.2.1 are untracked.
 ([#191](https://github.com/woodruffw/kbs2/pull/191))
 * CLI: `kbs2 rm` can now remove multiple records in one invocation
 ([#195](https://github.com/woodruffw/kbs2/pull/195))
+* CLI: `kbs2 agent query` enables users to query the agent for the status
+of a config's keypair ([#197](https://github.com/woodruffw/kbs2/pull/197))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Quick links:
   * [`kbs2 edit`](#kbs2-edit)
   * [`kbs2 generate`](#kbs2-generate)
   * [`kbs2 agent`](#kbs2-agent)
-  * [`kbs2 agent flush`](#kbs2-agent)
-  * [`kbs2 agent unwrap`](#kbs2-agent)
+  * [`kbs2 agent flush`](#kbs2-agent-flush)
+  * [`kbs2 agent unwrap`](#kbs2-agent-unwrap)
   * [`kbs2 rewrap`](#kbs2-rewrap)
   * [`kbs2 rekey`](#kbs2-rekey)
 * [Configuration](#configuration)
@@ -579,6 +579,45 @@ Remove all keys from the current `kbs2` agent:
 
 ```bash
 $ kbs2 agent flush
+```
+
+### `kbs2 agent query`
+
+#### Usage
+
+```
+ask the current agent whether it has the current config's key
+
+USAGE:
+    kbs2 agent query
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+```
+
+`kbs2 agent query` exits with a few discrete codes to signal the query status:
+
+* `0`: query succeeded, agent is running and has a keypair for the config's public key
+* `1`: query failed, agent is running but does not have the queried keypair
+* `2`: query failed, agent is running but the keypair isn't managed by the agent
+(i.e., it's an unwrapped keypair)
+* `3`: query failed, agent is not running
+
+All other error codes should be treated as an unspecified error that prevented a query.
+
+#### Examples
+
+Query the agent for the current config:
+
+```bash
+$ kbs2 agent query && echo "success" || echo "failure"
+```
+
+Query the agent for another config's keypair:
+
+```bash
+$ kbs2 -c /some/other/config agent query
 ```
 
 ### `kbs2 agent unwrap`

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ fn app<'a, P: AsRef<OsStr>>(default_config_dir: &'a P, default_store_dir: &'a P)
                         ),
                 )
                 .subcommand(
+                    App::new("query")
+                        .about("ask the current agent whether it has the current config's key"),
+                )
+                .subcommand(
                     App::new("unwrap")
                         .about("unwrap the current config's key in the running agent"),
                 ),


### PR DESCRIPTION
Allows scripts to check whether the agent has a keypair for the
current config. This is intended primarily as a plumbing command,
allowing users to query before performing any `kbs2` operations
that might block on user input or interaction.