### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -319,7 +319,7 @@ fn run(matches: &ArgMatches, config: &kbs2::config::Config) -> Result<()> {
             if !status.success() {
                 return Err(match status.code() {
                     Some(code) => anyhow!("{} failed: exited with {}", cmd, code),
-                    None => anyhow!("{} failed: terminated by signal"),
+                    None => anyhow!("{} failed: terminated by signal", cmd),
                 });
             }
         }


### PR DESCRIPTION
Without this, the error message would literally be "{} failed: terminated by signal" with curly braces in it instead of the command that failed.