### PR TITLE
README, src: change default config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All versions prior to 0.2.1 are untracked.
 * Meta: `kbs2` is now built with the 2021 edition of Rust
 ([#239](https://github.com/woodruffw/kbs2/pull/239))
 
+* Config: `kbs2` now checks for a `config.toml` file for its configuration.
+The legacy behavior (`kbs2.conf`) is preserved for backwards compatibility, but
+will be removed in an upcoming stable release.
+([#268](https://github.com/woodruffw/kbs2/pull/268))
+
 ## [0.4.0] - 2021-10-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -721,10 +721,14 @@ $ kbs2 -c /some/other/kbs2/conf/dir rekey
 
 ## Configuration
 
-`kbs2` stores its configuration in `<config dir>/kbs2/kbs2.conf`, where `<config dir>` is determined
+`kbs2` stores its configuration in `<config dir>/kbs2/config.toml`, where `<config dir>` is determined
 by your host system. On Linux, for example, it's `~/.config`.
 
-`kbs2.conf` is TOML-formatted, and might look something like this after a clean start with `kbs2 init`:
+**NOTE**: If `config.toml` isn't found in a configuration directory, `kbs2` attempts to use
+`kbs2.conf` in the same directory. This is for backwards compatibility, and will be removed
+once `kbs2` has its first stable release.
+
+`config.toml` is TOML-formatted, and might look something like this after a clean start with `kbs2 init`:
 
 ```toml
 public-key = "age1elujxyndwy0n9j2e2elmk9ns8vtltg69q620dr0sz4nu5fgj95xsl2peea"


### PR DESCRIPTION
`kbs2` now prefers `config.toml` over `kbs2.conf`.

The primary motivation for this change is the config editing experience: more editors will correctly detect TOML syntax when the filename ends in `.toml` than `.conf`.