### PR TITLE
src: refactor generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All versions prior to 0.2.1 are untracked.
 
 ### Changed
 
+* Generators, Config: `kbs2` generators now support multiple input
+alphabets, making it easier to enforce character requirements
+([#303](https://github.com/woodruffw/kbs2/pull/303))
+
 * Meta: `kbs2` is now built with the 2021 edition of Rust
 ([#239](https://github.com/woodruffw/kbs2/pull/239))
 

--- a/README.md
+++ b/README.md
@@ -968,10 +968,10 @@ the `post-hook`.
 `kbs2` supports *generators* for producing sensitive values, allowing users to automatically
 generate passwords and environment variables.
 
-Generators come in two flavors: "command" generators and "internal" generators. Both are
+Generators come in two flavors: "external" generators and "internal" generators. Both are
 configured as entries in `[[generators]]`.
 
-The following configures two generators: a "command" generator named "pwgen" that executes
+The following configures two generators: a "external" generator named "pwgen" that executes
 `pwgen` to get a new secret, and an "internal" generator named "hexonly" that generates
 a secret from the configured alphabet and length.
 
@@ -982,9 +982,29 @@ command = "pwgen 16 1"
 
 [[generators]]
 name = "hexonly"
-alphabet = "0123456789abcdef"
+alphabets = ["0123456789abcdef"]
 length = 16
 ```
+
+By default, `kbs2`'s configuration includes a `default` generator that looks
+something like this:
+
+```toml
+[[generators]]
+name = "default"
+# kbs2 samples from each alphabet, to ensure a good distribution of symbols
+alphabets = [
+    "abcdefghijklmnopqrstuvwxyz",
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "0123456789",
+    "(){}[]-_+=",
+]
+length = 16
+```
+
+`kbs2` also supports a legacy generator configuration that takes a single `alphabet`
+instead of `alphabets`. This configuration is deprecated and will be removed in
+an upcoming release.
 
 These generators can be used with `kbs2 new`:
 

--- a/src/kbs2/config.rs
+++ b/src/kbs2/config.rs
@@ -489,7 +489,7 @@ mod tests {
             post_hook: Some("false".into()),
             error_hook: Some("true".into()),
             reentrant_hooks: false,
-            generators: vec![GeneratorConfig::InternalLegacy(Default::default())],
+            generators: vec![GeneratorConfig::Internal(Default::default())],
             commands: CommandConfigs {
                 rm: RmConfig {
                     post_hook: Some("this-command-does-not-exist".into()),

--- a/src/kbs2/config.rs
+++ b/src/kbs2/config.rs
@@ -180,8 +180,9 @@ impl AsRef<OsStr> for Pinentry {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GeneratorConfig {
-    Command(GeneratorCommandConfig),
-    Internal(GeneratorInternalConfig),
+    Command(ExternalGeneratorConfig),
+    Internal(InternalGeneratorConfig),
+    InternalLegacy(LegacyInternalGeneratorConfig),
 }
 
 impl GeneratorConfig {
@@ -189,13 +190,14 @@ impl GeneratorConfig {
         match self {
             GeneratorConfig::Command(g) => g as &dyn Generator,
             GeneratorConfig::Internal(g) => g as &dyn Generator,
+            GeneratorConfig::InternalLegacy(g) => g as &dyn Generator,
         }
     }
 }
 
-/// The configuration settings for a "command" generator.
+/// The configuration settings for an external (i.e., separate command) generator.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct GeneratorCommandConfig {
+pub struct ExternalGeneratorConfig {
     /// The name of the generator.
     pub name: String,
 
@@ -203,29 +205,48 @@ pub struct GeneratorCommandConfig {
     pub command: String,
 }
 
-/// The configuration settings for an "internal" generator.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct GeneratorInternalConfig {
+pub struct InternalGeneratorConfig {
+    /// The name of the generator.
+    pub name: String,
+
+    /// The alphabets used by the generator.
+    pub alphabets: Vec<String>,
+
+    /// The length of the secrets generated.
+    pub length: usize,
+}
+
+impl Default for InternalGeneratorConfig {
+    fn default() -> Self {
+        InternalGeneratorConfig {
+            name: "default".into(),
+            alphabets: vec![
+                "abcdefghijklmnopqrstuvwxyz".into(),
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ".into(),
+                "0123456789".into(),
+                "(){}[]-_+=".into(),
+            ],
+            length: 16,
+        }
+    }
+}
+
+/// The configuration settings for a legacy "internal" generator.
+///
+/// This is a **legacy** generator that will be removed in an upcoming release.
+///
+/// Users should prefer `InternalGeneratorConfig`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LegacyInternalGeneratorConfig {
     /// The name of the generator.
     pub name: String,
 
     /// The alphabet to sample from when generating a secret.
     pub alphabet: String,
 
-    /// The number of characters to sample from the alphabet.
+    /// The length of the secrets generated.
     pub length: u32,
-}
-
-impl Default for GeneratorInternalConfig {
-    fn default() -> Self {
-        GeneratorInternalConfig {
-            name: "default".into(),
-            // NOTE(ww): This alphabet should be a decent default, as it contains
-            // symbols but not commonly blacklisted ones (e.g. %, $).
-            alphabet: "abcdefghijklmnopqrstuvwxyz0123456789(){}[]-_+=".into(),
-            length: 16,
-        }
-    }
 }
 
 /// The per-command configuration settings known to `kbs2`.
@@ -468,7 +489,7 @@ mod tests {
             post_hook: Some("false".into()),
             error_hook: Some("true".into()),
             reentrant_hooks: false,
-            generators: vec![GeneratorConfig::Internal(Default::default())],
+            generators: vec![GeneratorConfig::InternalLegacy(Default::default())],
             commands: CommandConfigs {
                 rm: RmConfig {
                     post_hook: Some("this-command-does-not-exist".into()),

--- a/src/kbs2/generator.rs
+++ b/src/kbs2/generator.rs
@@ -61,6 +61,8 @@ impl Generator for config::InternalGeneratorConfig {
                 ));
             }
 
+            // Safe unwrap: alphabet.chars() is always nonempty.
+            #[allow(clippy::unwrap_used)]
             secret.push(alphabet.chars().choose(&mut rng).unwrap());
         }
 

--- a/src/kbs2/session.rs
+++ b/src/kbs2/session.rs
@@ -149,7 +149,7 @@ mod tests {
             post_hook: None,
             error_hook: None,
             reentrant_hooks: false,
-            generators: vec![config::GeneratorConfig::InternalLegacy(Default::default())],
+            generators: vec![config::GeneratorConfig::Internal(Default::default())],
             commands: Default::default(),
         }
     }

--- a/src/kbs2/session.rs
+++ b/src/kbs2/session.rs
@@ -149,7 +149,7 @@ mod tests {
             post_hook: None,
             error_hook: None,
             reentrant_hooks: false,
-            generators: vec![config::GeneratorConfig::Internal(Default::default())],
+            generators: vec![config::GeneratorConfig::InternalLegacy(Default::default())],
             commands: Default::default(),
         }
     }


### PR DESCRIPTION
Refactors "internal" generators to make them both more flexible and capable of generating better secrets.

The old behavior is preserved for backwards compatibility.