### PR TITLE
src: add `kbs2 config dump`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ All versions prior to 0.2.1 are untracked.
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+* CLI: The `kbs2 config` and `kbs2 config dump` subcommands have been added,
+allowing for easy access to the active configuration state in JSON
+([#304](https://github.com/woodruffw/kbs2/pull/304))
+
+* Contrib: All contrib scripts have been refactored to take advantage of
+`kbs2 config dump` ([#304](https://github.com/woodruffw/kbs2/pull/304))
+
 ## [0.5.0] - 2022-02-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Quick links:
   * [`kbs2 edit`](#kbs2-edit)
   * [`kbs2 generate`](#kbs2-generate)
   * [`kbs2 agent`](#kbs2-agent)
-  * [`kbs2 agent flush`](#kbs2-agent-flush)
-  * [`kbs2 agent unwrap`](#kbs2-agent-unwrap)
+    * [`kbs2 agent flush`](#kbs2-agent-flush)
+    * [`kbs2 agent unwrap`](#kbs2-agent-unwrap)
   * [`kbs2 rewrap`](#kbs2-rewrap)
   * [`kbs2 rekey`](#kbs2-rekey)
+  * [`kbs2 config`](#kbs2-config)
+    * [`kbs2 config dump`](#kbs2-config-dump)
 * [Configuration](#configuration)
   * [Generators](#generators)
 * [Customization](#customization)
@@ -719,6 +721,50 @@ Re-key a different configuration and store:
 $ kbs2 -c /some/other/kbs2/conf/dir rekey
 ```
 
+### `kbs2 config`
+
+#### Usage
+
+```
+interact with kbs2's configuration file
+
+USAGE:
+    kbs2 config <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    dump    dump the active configuration file as JSON
+    help    Print this message or the help of the given subcommand(s)
+```
+
+### `kbs2 config dump`
+
+#### Usage
+
+```
+dump the active configuration file as JSON
+
+USAGE:
+    kbs2 config dump [OPTIONS]
+
+OPTIONS:
+    -h, --help      Print help information
+    -p, --pretty    pretty-print the JSON
+```
+
+#### Examples
+
+Dump the current configuration as JSON:
+
+```bash
+$ kbs2 config dump
+
+# pretty-print the dumped JSON
+$ kbs2 config dump --pretty
+```
+
 ## Configuration
 
 `kbs2` stores its configuration in `<config dir>/kbs2/config.toml`, where `<config dir>` is determined
@@ -1036,6 +1082,8 @@ When run via `kbs2`, custom commands receive the following environment variables
 * `KBS2_CONFIG_DIR`: The path to the configuration directory that `kbs2` itself was loaded with.
 Subcommands can use this path to read the current configuration file or any other content stored
 in the configuration directory.
+    * **NOTE**: Subcommands are encouraged to use `kbs2 config dump` to read the configuration
+    state instead of attempting to find the correct file manually.
 * `KBS2_STORE`: The path to the secret store.
 * `KBS2_SUBCOMMAND`: Always set to `1`. This can be used to determine whether a subcommand was run
 via `kbs2` (e.g. `kbs2 foo`) versus directly (e.g. `kbs2-foo`).

--- a/contrib/ext-cmds/kbs2-choose-pass/kbs2-choose-pass
+++ b/contrib/ext-cmds/kbs2-choose-pass/kbs2-choose-pass
@@ -16,13 +16,11 @@ function installed() {
 
 function maybe_notify_username() {
   label="${1}"
-  config="${KBS2_CONFIG_DIR}/kbs2.conf"
 
-  [[ -f "${config}" ]] || return
-  installed jq && installed toml2json || return
+  installed jq || return
 
   setting=$(
-    toml2json < "${config}" \
+    kbs2 config dump \
       | jq --raw-output '.commands.ext."choose-pass"."notify-username" or false'
   )
 

--- a/contrib/ext-cmds/kbs2-dmenu-pass/kbs2-dmenu-pass
+++ b/contrib/ext-cmds/kbs2-dmenu-pass/kbs2-dmenu-pass
@@ -16,13 +16,11 @@ function installed() {
 
 function maybe_notify_username() {
   label="${1}"
-  config="${KBS2_CONFIG_DIR}/kbs2.conf"
 
-  [[ -f "${config}" ]] || return
-  installed jq && installed toml2json || return
+  installed jq || return
 
   setting=$(
-    toml2json < "${config}" \
+    kbs2 config dump \
       | jq --raw-output '.commands.ext."dmenu-pass"."notify-username" or false'
   )
 

--- a/contrib/ext-cmds/kbs2-snip/kbs2-snip
+++ b/contrib/ext-cmds/kbs2-snip/kbs2-snip
@@ -7,7 +7,6 @@
 require "open3"
 require "optparse"
 require "json"
-require "tomlrb"
 
 abort "Fatal: Not being run as a subcommand?" unless ENV.key? "KBS2_SUBCOMMAND"
 
@@ -22,10 +21,7 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-config = begin
-  config_file = File.join ENV["KBS2_CONFIG_DIR"], "kbs2.conf"
-  Tomlrb.load_file config_file
-end
+config = JSON.parse `kbs2 config dump`
 
 matcher = config.dig("commands", "ext", "snip", "matcher") || "selecta"
 

--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 use std::env;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -53,6 +53,7 @@ pub fn init(matches: &ArgMatches, config_dir: &Path) -> Result<()> {
 pub fn agent(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     log::debug!("agent subcommand dispatch");
 
+    // No subcommand: run the agent itself
     if matches.subcommand().is_none() {
         let mut agent = agent::Agent::new()?;
         if !matches.is_present("foreground") {
@@ -62,7 +63,6 @@ pub fn agent(matches: &ArgMatches, config: &config::Config) -> Result<()> {
         return Ok(());
     }
 
-    // No subcommand: run the agent itself
     match matches.subcommand() {
         Some(("flush", matches)) => agent_flush(matches),
         Some(("query", matches)) => agent_query(matches, config),
@@ -695,6 +695,25 @@ pub fn rekey(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     }
 
     println!("All done.");
+
+    Ok(())
+}
+
+/// Implements the `kbs2 config` command.
+pub fn config(matches: &ArgMatches, config: &config::Config) -> Result<()> {
+    log::debug!("config subcommand dispatch");
+
+    match matches.subcommand() {
+        Some(("dump", matches)) => {
+            if matches.is_present("pretty") {
+                serde_json::to_writer_pretty(io::stdout(), &config)?;
+            } else {
+                serde_json::to_writer(io::stdout(), &config)?;
+            }
+        }
+        Some((_, _)) => unreachable!(),
+        None => unreachable!(),
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,21 @@ fn app() -> App<'static> {
                         .long("no-backup"),
                 ),
         )
+        .subcommand(
+            App::new("config")
+                .setting(AppSettings::SubcommandRequired)
+                .about("interact with kbs2's configuration file")
+                .subcommand(
+                    App::new("dump")
+                        .about("dump the active configuration file as JSON")
+                        .arg(
+                            Arg::new("pretty")
+                                .help("pretty-print the JSON")
+                                .short('p')
+                                .long("pretty"),
+                        ),
+                ),
+        )
 }
 
 fn run(matches: &ArgMatches, config: &kbs2::config::Config) -> Result<()> {
@@ -297,6 +312,7 @@ fn run(matches: &ArgMatches, config: &kbs2::config::Config) -> Result<()> {
         Some(("generate", matches)) => kbs2::command::generate(matches, config)?,
         Some(("rewrap", matches)) => kbs2::command::rewrap(matches, config)?,
         Some(("rekey", matches)) => kbs2::command::rekey(matches, config)?,
+        Some(("config", matches)) => kbs2::command::config(matches, config)?,
         Some((cmd, matches)) => {
             let cmd = format!("kbs2-{}", cmd);
 


### PR DESCRIPTION
This avoids the dance that external commands need to do to discover the config file and parse it on their own.