### PR TITLE
Fix `kbs2 edit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All versions prior to 0.2.1 are untracked.
 * Support for deprecated "legacy" secret generators has been fully removed
 ([#419](https://github.com/woodruffw/kbs2/pull/419))
 
+### Fixed
+
+* `kbs2 edit` now allows for the use of command line text editors
+([#435](https://github.com/woodruffw/kbs2/pull/435))
+
 ## [0.6.0] - 2022-06-28
 
 ### Added

--- a/src/kbs2/command.rs
+++ b/src/kbs2/command.rs
@@ -460,8 +460,8 @@ pub fn edit(matches: &ArgMatches, config: &config::Config) -> Result<()> {
     if !process::Command::new(&editor)
         .args(&editor_args)
         .arg(file.path())
-        .output()
-        .map_or(false, |o| o.status.success())
+        .status()
+        .map_or(false, |o| o.success())
     {
         return Err(anyhow!("failed to run the editor"));
     }


### PR DESCRIPTION
This should enable the use of cli editors when using `kbs2 edit` so it should fix the first part of #434  