### PR TITLE
kbs2-qr: fail gracefully when record doesn't exist

### DIFF
--- a/contrib/ext-cmds/kbs2-qr/kbs2-qr
+++ b/contrib/ext-cmds/kbs2-qr/kbs2-qr
@@ -26,6 +26,6 @@ fi
 [[ -n "${1}" ]] || { echo "Usage: kbs2 qr <login>"; exit; }
 
 password=$(kbs2 pass "${1}")
-[[ -z "${password}" ]] && { echo "No such record: ${1}"; exit 1; }
+[[ -z "${password}" ]] && { echo "No such login: ${1}"; exit 1; }
 
 qrencode -s 12 -o - <<< "${password}" | ${display}

--- a/contrib/ext-cmds/kbs2-qr/kbs2-qr
+++ b/contrib/ext-cmds/kbs2-qr/kbs2-qr
@@ -25,4 +25,7 @@ fi
 
 [[ -n "${1}" ]] || { echo "Usage: kbs2 qr <login>"; exit; }
 
-kbs2 pass "${1}" | qrencode -s 12 -o - | ${display}
+password=$(kbs2 pass "${1}")
+[[ -z "${password}" ]] && { echo "No such record: ${1}"; exit 1; }
+
+qrencode -s 12 -o - <<< "${password}" | ${display}


### PR DESCRIPTION
Improves the error message presented when `kbs2 qr` is handed a nonexistent login record (or a record that isn't a login).